### PR TITLE
Build HackFlow full‑stack platform with auth, CRUD APIs, UI and seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,90 @@
-# Next.js Admin UI Base
+# HackFlow - Full-Stack Dynamic Website
 
-This project is a minimal Next.js app configured with Tailwind CSS and [shadcn/ui](https://ui.shadcn.com/) components. IBM Plex Sans is bundled locally using `@fontsource/ibm-plex-sans` and loaded with `next/font`.
+HackFlow is a hackathon-ready full-stack project built with **Next.js + Tailwind CSS**. It includes:
 
-## Getting Started
+- Modern responsive UI (desktop + mobile)
+- User auth (signup/login/logout) using signed JWT-style cookies
+- Dynamic CRUD posts (create/edit/delete)
+- API routes with auth protection
+- Reusable components and global state using React Context
+- Seed script with demo users and posts
 
-Install dependencies and run the development server:
+## Tech Stack
+
+- **Frontend**: Next.js App Router, React, Tailwind CSS
+- **Backend**: Next.js Route Handlers (Node runtime)
+- **Data Layer**: JSON datastore (`data/db.json`) with seed script
+- **Auth**: Cookie-based signed tokens + secure password hashing (`crypto.scrypt`)
+
+> If you want to upgrade to MongoDB later, you can replace `lib/db.js` with a Mongo client/model layer while preserving API and UI contracts.
+
+## Setup
 
 ```bash
 npm install
+npm run seed
 npm run dev
 ```
 
-You can build the project using:
+Open: `http://localhost:3000`
+
+### Demo credentials after seeding
+
+- `aarav@example.com` / `password123`
+- `siya@example.com` / `password123`
+
+## Environment Variables
+
+Create `.env.local`:
 
 ```bash
-npm run build
+JWT_SECRET=replace_with_long_random_secret
 ```
 
-## Project Structure
+## Key Routes
 
-- `app/` – Next.js app router pages and layout
-- `components/` – reusable UI components
-- `lib/` – shared utilities
+- `/` - Landing page
+- `/signup` - Register
+- `/login` - Login
+- `/dashboard` - Authenticated posting workspace
 
-The default page displays a simple "Hello World" heading.
+## API Routes
 
-## Notes
+- `POST /api/auth/signup`
+- `POST /api/auth/login`
+- `POST /api/auth/logout`
+- `GET /api/auth/me`
+- `GET /api/posts`
+- `POST /api/posts`
+- `PUT /api/posts/:id`
+- `DELETE /api/posts/:id`
 
-This repository provides the base for an internal admin tool that will integrate with Mailmodo APIs in the future.
+## Folder Structure
+
+```text
+app/
+  api/
+    auth/
+    posts/
+  dashboard/
+  login/
+  signup/
+components/
+  layout/
+  posts/
+  providers/
+lib/
+  auth.js
+  db.js
+  http.js
+data/
+  db.json
+scripts/
+  seed.mjs
+```
+
+## Notes for Maintainability
+
+- Clear modular files by concern (auth, data, transport, UI).
+- Inline comments added for important utility flows.
+- Reusable `PostForm`, `PostCard`, and `AuthProvider` components.

--- a/app/api/auth/login/route.js
+++ b/app/api/auth/login/route.js
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { readDb } from '@/lib/db';
+import { verifyPassword, signToken } from '@/lib/auth';
+import { authCookieOptions } from '@/lib/http';
+
+export async function POST(request) {
+  const { email, password } = await request.json();
+
+  if (!email || !password) {
+    return NextResponse.json({ error: 'Email and password are required.' }, { status: 400 });
+  }
+
+  const db = await readDb();
+  const normalizedEmail = email.trim().toLowerCase();
+  const user = db.users.find((candidate) => candidate.email === normalizedEmail);
+
+  if (!user || !(await verifyPassword(password, user.passwordHash))) {
+    return NextResponse.json({ error: 'Invalid credentials.' }, { status: 401 });
+  }
+
+  const token = signToken({ userId: user.id, email: user.email, name: user.name });
+  const response = NextResponse.json({ user: { id: user.id, name: user.name, email: user.email } });
+  response.cookies.set('auth_token', token, authCookieOptions());
+
+  return response;
+}

--- a/app/api/auth/logout/route.js
+++ b/app/api/auth/logout/route.js
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  const response = NextResponse.json({ ok: true });
+  response.cookies.set('auth_token', '', {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    maxAge: 0,
+  });
+  return response;
+}

--- a/app/api/auth/me/route.js
+++ b/app/api/auth/me/route.js
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { getCurrentUserFromCookie } from '@/lib/http';
+
+export async function GET() {
+  const user = await getCurrentUserFromCookie();
+  if (!user) {
+    return NextResponse.json({ user: null }, { status: 401 });
+  }
+  return NextResponse.json({ user });
+}

--- a/app/api/auth/signup/route.js
+++ b/app/api/auth/signup/route.js
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { createId, readDb, writeDb } from '@/lib/db';
+import { hashPassword, signToken } from '@/lib/auth';
+import { authCookieOptions } from '@/lib/http';
+
+export async function POST(request) {
+  const { name, email, password } = await request.json();
+
+  if (!name || !email || !password) {
+    return NextResponse.json({ error: 'Name, email, and password are required.' }, { status: 400 });
+  }
+
+  const db = await readDb();
+  const normalizedEmail = email.trim().toLowerCase();
+
+  if (db.users.some((user) => user.email === normalizedEmail)) {
+    return NextResponse.json({ error: 'Email already exists.' }, { status: 409 });
+  }
+
+  const user = {
+    id: createId('user'),
+    name: name.trim(),
+    email: normalizedEmail,
+    passwordHash: await hashPassword(password),
+    createdAt: new Date().toISOString(),
+  };
+
+  db.users.push(user);
+  await writeDb(db);
+
+  const token = signToken({ userId: user.id, email: user.email, name: user.name });
+  const response = NextResponse.json({ user: { id: user.id, name: user.name, email: user.email } });
+  response.cookies.set('auth_token', token, authCookieOptions());
+
+  return response;
+}

--- a/app/api/posts/[id]/route.js
+++ b/app/api/posts/[id]/route.js
@@ -1,0 +1,48 @@
+import { NextResponse } from 'next/server';
+import { readDb, writeDb } from '@/lib/db';
+import { getCurrentUserFromCookie } from '@/lib/http';
+
+export async function PUT(request, { params }) {
+  const user = await getCurrentUserFromCookie();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { id } = params;
+  const { title, content } = await request.json();
+
+  const db = await readDb();
+  const index = db.posts.findIndex((post) => post.id === id);
+
+  if (index === -1) return NextResponse.json({ error: 'Post not found.' }, { status: 404 });
+  if (db.posts[index].authorId !== user.userId) {
+    return NextResponse.json({ error: 'Forbidden.' }, { status: 403 });
+  }
+
+  db.posts[index] = {
+    ...db.posts[index],
+    title: title?.trim() || db.posts[index].title,
+    content: content?.trim() || db.posts[index].content,
+    updatedAt: new Date().toISOString(),
+  };
+
+  await writeDb(db);
+  return NextResponse.json({ post: { ...db.posts[index], author: user.name } });
+}
+
+export async function DELETE(_request, { params }) {
+  const user = await getCurrentUserFromCookie();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { id } = params;
+  const db = await readDb();
+  const post = db.posts.find((candidate) => candidate.id === id);
+
+  if (!post) return NextResponse.json({ error: 'Post not found.' }, { status: 404 });
+  if (post.authorId !== user.userId) {
+    return NextResponse.json({ error: 'Forbidden.' }, { status: 403 });
+  }
+
+  db.posts = db.posts.filter((candidate) => candidate.id !== id);
+  await writeDb(db);
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/posts/route.js
+++ b/app/api/posts/route.js
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { createId, readDb, writeDb } from '@/lib/db';
+import { getCurrentUserFromCookie } from '@/lib/http';
+
+export async function GET() {
+  const db = await readDb();
+  const posts = [...db.posts]
+    .sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt))
+    .map((post) => ({
+      ...post,
+      author: db.users.find((u) => u.id === post.authorId)?.name || 'Unknown',
+    }));
+
+  return NextResponse.json({ posts });
+}
+
+export async function POST(request) {
+  const user = await getCurrentUserFromCookie();
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const { title, content } = await request.json();
+  if (!title || !content) {
+    return NextResponse.json({ error: 'Title and content are required.' }, { status: 400 });
+  }
+
+  const db = await readDb();
+  const now = new Date().toISOString();
+
+  const post = {
+    id: createId('post'),
+    title: title.trim(),
+    content: content.trim(),
+    authorId: user.userId,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  db.posts.push(post);
+  await writeDb(db);
+
+  return NextResponse.json({ post: { ...post, author: user.name } }, { status: 201 });
+}

--- a/app/dashboard/page.jsx
+++ b/app/dashboard/page.jsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import PostForm from '@/components/posts/PostForm';
+import PostCard from '@/components/posts/PostCard';
+import { useAuth } from '@/components/providers/AuthProvider';
+
+async function fetchJson(url, options) {
+  const response = await fetch(url, options);
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(data.error || 'Request failed');
+  return data;
+}
+
+export default function DashboardPage() {
+  const router = useRouter();
+  const { user, loading } = useAuth();
+  const [posts, setPosts] = useState([]);
+  const [editingPost, setEditingPost] = useState(null);
+  const [error, setError] = useState('');
+
+  async function loadPosts() {
+    try {
+      const data = await fetchJson('/api/posts');
+      setPosts(data.posts);
+    } catch (err) {
+      setError(err.message);
+    }
+  }
+
+  useEffect(() => {
+    loadPosts();
+  }, []);
+
+  useEffect(() => {
+    if (!loading && !user) router.push('/login');
+  }, [user, loading, router]);
+
+  if (loading || !user) {
+    return <p className="text-gray-500">Loading dashboard...</p>;
+  }
+
+  return (
+    <section className="grid gap-6 lg:grid-cols-[1fr_2fr]">
+      <div className="space-y-3">
+        <div className="rounded-2xl bg-gradient-to-r from-indigo-600 to-violet-600 p-5 text-white">
+          <p className="text-sm opacity-90">Welcome back</p>
+          <h1 className="text-2xl font-bold">{user.name}</h1>
+          <p className="text-xs opacity-80">{user.email}</p>
+        </div>
+        <PostForm
+          initialPost={editingPost}
+          onCancel={() => setEditingPost(null)}
+          onSave={async (payload) => {
+            if (editingPost) {
+              await fetchJson(`/api/posts/${editingPost.id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+              });
+              setEditingPost(null);
+            } else {
+              await fetchJson('/api/posts', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+              });
+            }
+            await loadPosts();
+          }}
+        />
+      </div>
+      <div className="space-y-4">
+        <h2 className="text-2xl font-bold text-gray-900">Recent Posts</h2>
+        {error ? <p className="text-sm text-red-600">{error}</p> : null}
+        <div className="space-y-3">
+          {posts.map((post) => (
+            <PostCard
+              key={post.id}
+              post={post}
+              canManage={post.authorId === user.userId}
+              onEdit={(candidate) => setEditingPost(candidate)}
+              onDelete={async (id) => {
+                await fetchJson(`/api/posts/${id}`, { method: 'DELETE' });
+                await loadPosts();
+              }}
+            />
+          ))}
+          {!posts.length ? <p className="text-gray-500">No posts yet. Publish your first post.</p> : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,36 +1,44 @@
-import localFont from "next/font/local";
-import "./globals.css";
+import localFont from 'next/font/local';
+import './globals.css';
+import { AuthProvider } from '@/components/providers/AuthProvider';
+import Navbar from '@/components/layout/Navbar';
 
 const ibmPlexSans = localFont({
   src: [
     {
-      path: "../node_modules/@fontsource/ibm-plex-sans/files/ibm-plex-sans-latin-400-normal.woff2",
-      weight: "400",
-      style: "normal",
+      path: '../node_modules/@fontsource/ibm-plex-sans/files/ibm-plex-sans-latin-400-normal.woff2',
+      weight: '400',
+      style: 'normal',
     },
     {
-      path: "../node_modules/@fontsource/ibm-plex-sans/files/ibm-plex-sans-latin-500-normal.woff2",
-      weight: "500",
-      style: "normal",
+      path: '../node_modules/@fontsource/ibm-plex-sans/files/ibm-plex-sans-latin-500-normal.woff2',
+      weight: '500',
+      style: 'normal',
     },
     {
-      path: "../node_modules/@fontsource/ibm-plex-sans/files/ibm-plex-sans-latin-700-normal.woff2",
-      weight: "700",
-      style: "normal",
+      path: '../node_modules/@fontsource/ibm-plex-sans/files/ibm-plex-sans-latin-700-normal.woff2',
+      weight: '700',
+      style: 'normal',
     },
   ],
-  variable: "--font-ibm-plex-sans",
-  display: "swap",
+  variable: '--font-ibm-plex-sans',
+  display: 'swap',
 });
 
 export const metadata = {
-  title: "Hello World App",
+  title: 'HackFlow - Dynamic Posting Platform',
+  description: 'A responsive, full-stack posting platform with authentication and CRUD features.',
 };
 
 export default function RootLayout({ children }) {
   return (
     <html lang="en" className="h-full">
-      <body className={`${ibmPlexSans.variable} min-h-screen`}>{children}</body>
+      <body className={`${ibmPlexSans.variable} min-h-screen bg-slate-50`}>
+        <AuthProvider>
+          <Navbar />
+          <main className="mx-auto w-full max-w-6xl px-4 py-6 md:px-6">{children}</main>
+        </AuthProvider>
+      </body>
     </html>
   );
-} 
+}

--- a/app/login/page.jsx
+++ b/app/login/page.jsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/components/providers/AuthProvider';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const { login } = useAuth();
+  const [form, setForm] = useState({ email: '', password: '' });
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  return (
+    <section className="mx-auto max-w-md">
+      <form
+        className="slide-up space-y-4 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm"
+        onSubmit={async (event) => {
+          event.preventDefault();
+          setError('');
+          setSubmitting(true);
+          try {
+            await login(form);
+            router.push('/dashboard');
+          } catch (err) {
+            setError(err.message);
+          } finally {
+            setSubmitting(false);
+          }
+        }}
+      >
+        <h1 className="text-2xl font-bold">Login</h1>
+        <input
+          type="email"
+          placeholder="Email"
+          value={form.email}
+          onChange={(event) => setForm((old) => ({ ...old, email: event.target.value }))}
+          className="w-full rounded-xl border border-gray-300 px-3 py-2"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={form.password}
+          onChange={(event) => setForm((old) => ({ ...old, password: event.target.value }))}
+          className="w-full rounded-xl border border-gray-300 px-3 py-2"
+          required
+        />
+        {error ? <p className="text-sm text-red-600">{error}</p> : null}
+        <button disabled={submitting} className="w-full rounded-xl bg-indigo-600 px-4 py-2 text-white" type="submit">
+          {submitting ? 'Logging in...' : 'Login'}
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -1,5 +1,32 @@
-import AdminDashboard from '../components/AdminDashboard';
+import Link from 'next/link';
 
 export default function Home() {
-  return <AdminDashboard />;
-} 
+  return (
+    <section className="fade-in grid gap-6 md:grid-cols-2 md:items-center">
+      <div className="space-y-4">
+        <span className="inline-flex rounded-full bg-indigo-100 px-3 py-1 text-xs font-semibold text-indigo-700">Hackathon Ready</span>
+        <h1 className="text-4xl font-bold leading-tight text-gray-900 md:text-5xl">Build, publish, and manage dynamic content in minutes.</h1>
+        <p className="text-gray-600">
+          HackFlow is a fully responsive starter platform featuring secure authentication, API-powered CRUD, reusable components, and clean modern UI.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <Link href="/signup" className="rounded-xl bg-indigo-600 px-5 py-3 font-medium text-white transition hover:bg-indigo-500">
+            Create account
+          </Link>
+          <Link href="/dashboard" className="rounded-xl bg-gray-200 px-5 py-3 font-medium text-gray-900 transition hover:bg-gray-300">
+            Open dashboard
+          </Link>
+        </div>
+      </div>
+      <div className="scale-in rounded-3xl border border-indigo-100 bg-white p-6 shadow-lg">
+        <ul className="space-y-3 text-gray-700">
+          <li>✅ JWT-style cookie auth flow (signup/login/logout)</li>
+          <li>✅ Database-backed posts with create/edit/delete APIs</li>
+          <li>✅ Responsive mobile-first design</li>
+          <li>✅ Smooth transitions and animated cards</li>
+          <li>✅ Seed script with sample users and posts</li>
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/app/signup/page.jsx
+++ b/app/signup/page.jsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/components/providers/AuthProvider';
+
+export default function SignupPage() {
+  const router = useRouter();
+  const { signup } = useAuth();
+  const [form, setForm] = useState({ name: '', email: '', password: '' });
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  return (
+    <section className="mx-auto max-w-md">
+      <form
+        className="slide-up space-y-4 rounded-2xl border border-gray-200 bg-white p-6 shadow-sm"
+        onSubmit={async (event) => {
+          event.preventDefault();
+          setError('');
+          setSubmitting(true);
+          try {
+            await signup(form);
+            router.push('/dashboard');
+          } catch (err) {
+            setError(err.message);
+          } finally {
+            setSubmitting(false);
+          }
+        }}
+      >
+        <h1 className="text-2xl font-bold">Create Account</h1>
+        <input
+          type="text"
+          placeholder="Name"
+          value={form.name}
+          onChange={(event) => setForm((old) => ({ ...old, name: event.target.value }))}
+          className="w-full rounded-xl border border-gray-300 px-3 py-2"
+          required
+        />
+        <input
+          type="email"
+          placeholder="Email"
+          value={form.email}
+          onChange={(event) => setForm((old) => ({ ...old, email: event.target.value }))}
+          className="w-full rounded-xl border border-gray-300 px-3 py-2"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={form.password}
+          onChange={(event) => setForm((old) => ({ ...old, password: event.target.value }))}
+          className="w-full rounded-xl border border-gray-300 px-3 py-2"
+          required
+          minLength={6}
+        />
+        {error ? <p className="text-sm text-red-600">{error}</p> : null}
+        <button disabled={submitting} className="w-full rounded-xl bg-indigo-600 px-4 py-2 text-white" type="submit">
+          {submitting ? 'Creating account...' : 'Signup'}
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/components/layout/Navbar.jsx
+++ b/components/layout/Navbar.jsx
@@ -1,0 +1,44 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
+import { useAuth } from '../providers/AuthProvider';
+
+export default function Navbar() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { user, logout, loading } = useAuth();
+
+  const navClass = (href) =>
+    `rounded-full px-4 py-2 text-sm transition ${pathname === href ? 'bg-indigo-600 text-white' : 'text-gray-600 hover:bg-gray-200'}`;
+
+  return (
+    <header className="sticky top-0 z-50 border-b border-gray-200 bg-white/90 backdrop-blur">
+      <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-3 md:px-6">
+        <Link href="/" className="text-lg font-bold text-gray-900">HackFlow</Link>
+        <nav className="flex items-center gap-2">
+          <Link href="/" className={navClass('/')}>Home</Link>
+          <Link href="/dashboard" className={navClass('/dashboard')}>Dashboard</Link>
+          {!loading && !user ? (
+            <>
+              <Link href="/login" className={navClass('/login')}>Login</Link>
+              <Link href="/signup" className={navClass('/signup')}>Signup</Link>
+            </>
+          ) : null}
+          {!loading && user ? (
+            <button
+              type="button"
+              onClick={async () => {
+                await logout();
+                router.push('/');
+              }}
+              className="rounded-full bg-gray-900 px-4 py-2 text-sm text-white transition hover:bg-gray-700"
+            >
+              Logout
+            </button>
+          ) : null}
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/components/posts/PostCard.jsx
+++ b/components/posts/PostCard.jsx
@@ -1,0 +1,27 @@
+'use client';
+
+export default function PostCard({ post, canManage, onEdit, onDelete }) {
+  return (
+    <article className="slide-up rounded-2xl border border-gray-200 bg-white p-4 shadow-sm transition hover:shadow-md">
+      <div className="mb-2 flex items-start justify-between gap-4">
+        <div>
+          <h4 className="text-xl font-semibold text-gray-900">{post.title}</h4>
+          <p className="text-xs text-gray-500">
+            By {post.author} • Updated {new Date(post.updatedAt).toLocaleString()}
+          </p>
+        </div>
+        {canManage ? (
+          <div className="flex gap-2">
+            <button type="button" className="rounded bg-gray-100 px-2 py-1 text-xs" onClick={() => onEdit(post)}>
+              Edit
+            </button>
+            <button type="button" className="rounded bg-red-100 px-2 py-1 text-xs text-red-700" onClick={() => onDelete(post.id)}>
+              Delete
+            </button>
+          </div>
+        ) : null}
+      </div>
+      <p className="whitespace-pre-wrap text-gray-700">{post.content}</p>
+    </article>
+  );
+}

--- a/components/posts/PostForm.jsx
+++ b/components/posts/PostForm.jsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function PostForm({ onSave, initialPost, onCancel }) {
+  const [title, setTitle] = useState(initialPost?.title || '');
+  const [content, setContent] = useState(initialPost?.content || '');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  return (
+    <form
+      className="space-y-3 rounded-2xl border border-gray-200 bg-white p-4 shadow-sm"
+      onSubmit={async (event) => {
+        event.preventDefault();
+        setError('');
+        setSubmitting(true);
+        try {
+          await onSave({ title, content });
+          if (!initialPost) {
+            setTitle('');
+            setContent('');
+          }
+        } catch (err) {
+          setError(err.message);
+        } finally {
+          setSubmitting(false);
+        }
+      }}
+    >
+      <h3 className="text-lg font-semibold text-gray-900">{initialPost ? 'Edit Post' : 'Create a Post'}</h3>
+      <input
+        value={title}
+        onChange={(event) => setTitle(event.target.value)}
+        className="w-full rounded-xl border border-gray-300 px-3 py-2 outline-none ring-indigo-500 transition focus:ring"
+        placeholder="Post title"
+        required
+      />
+      <textarea
+        value={content}
+        onChange={(event) => setContent(event.target.value)}
+        rows={5}
+        className="w-full rounded-xl border border-gray-300 px-3 py-2 outline-none ring-indigo-500 transition focus:ring"
+        placeholder="Write your content..."
+        required
+      />
+      {error ? <p className="text-sm text-red-600">{error}</p> : null}
+      <div className="flex gap-2">
+        <button
+          disabled={submitting}
+          className="rounded-xl bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-indigo-500 disabled:opacity-60"
+          type="submit"
+        >
+          {submitting ? 'Saving...' : initialPost ? 'Update Post' : 'Publish Post'}
+        </button>
+        {initialPost ? (
+          <button type="button" onClick={onCancel} className="rounded-xl bg-gray-100 px-4 py-2 text-sm text-gray-800">
+            Cancel
+          </button>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/components/providers/AuthProvider.jsx
+++ b/components/providers/AuthProvider.jsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+
+const AuthContext = createContext(null);
+
+async function parseJson(response) {
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) throw new Error(data.error || 'Request failed');
+  return data;
+}
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const response = await fetch('/api/auth/me');
+        if (!response.ok) throw new Error('Not authenticated');
+        const data = await response.json();
+        setUser(data.user);
+      } catch {
+        setUser(null);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      user,
+      loading,
+      async signup(payload) {
+        const data = await parseJson(
+          await fetch('/api/auth/signup', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          }),
+        );
+        setUser(data.user);
+      },
+      async login(payload) {
+        const data = await parseJson(
+          await fetch('/api/auth/login', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          }),
+        );
+        setUser(data.user);
+      },
+      async logout() {
+        await fetch('/api/auth/logout', { method: 'POST' });
+        setUser(null);
+      },
+    }),
+    [user, loading],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (!context) throw new Error('useAuth must be used within AuthProvider');
+  return context;
+}

--- a/data/db.json
+++ b/data/db.json
@@ -1,0 +1,36 @@
+{
+  "users": [
+    {
+      "id": "user_1773454654288_0d961736",
+      "name": "Aarav Demo",
+      "email": "aarav@example.com",
+      "passwordHash": "2f714b980f7dcc71a1b2235abedf23c8:8db7ab9ac639e4e4aa9ad09b5692653377db81ab74fa53462df81e27d59a31a3e85dabddb35b8426d94be70001074fdba63f745f2a4a72d4fdce68a4269ce8d1",
+      "createdAt": "2026-03-14T02:17:34.287Z"
+    },
+    {
+      "id": "user_1773454654288_04909f90",
+      "name": "Siya Demo",
+      "email": "siya@example.com",
+      "passwordHash": "754ddc065dcfbf7925ef44a755ff6a33:5c24ffac0a1907808a86b1e872347de6b2b6c4df443a58353a45cb171d1787c1c6e39c7f6c1e9ae40e62cfb493ade92e099fffbf182322203195cf0d8ab5bdfb",
+      "createdAt": "2026-03-14T02:17:34.287Z"
+    }
+  ],
+  "posts": [
+    {
+      "id": "post_1773454654537_a7d21d5d",
+      "title": "Welcome to HackFlow",
+      "content": "This sample post was seeded automatically. Start building from here!",
+      "authorId": "user_1773454654288_0d961736",
+      "createdAt": "2026-03-14T02:17:34.287Z",
+      "updatedAt": "2026-03-14T02:17:34.287Z"
+    },
+    {
+      "id": "post_1773454654537_08419356",
+      "title": "Hackathon Tip",
+      "content": "Keep your modules small and reusable to move faster under pressure.",
+      "authorId": "user_1773454654288_04909f90",
+      "createdAt": "2026-03-14T02:17:34.287Z",
+      "updatedAt": "2026-03-14T02:17:34.287Z"
+    }
+  ]
+}

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -1,0 +1,87 @@
+import crypto from 'crypto';
+
+const TOKEN_SECRET = process.env.JWT_SECRET || 'dev_secret_change_me';
+
+function base64UrlEncode(value) {
+  return Buffer.from(value)
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+function base64UrlDecode(value) {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padding = '='.repeat((4 - (normalized.length % 4)) % 4);
+  return Buffer.from(normalized + padding, 'base64').toString('utf-8');
+}
+
+export async function hashPassword(password) {
+  const salt = crypto.randomBytes(16).toString('hex');
+  const derivedKey = await new Promise((resolve, reject) => {
+    crypto.scrypt(password, salt, 64, (error, key) => {
+      if (error) reject(error);
+      else resolve(key.toString('hex'));
+    });
+  });
+  return `${salt}:${derivedKey}`;
+}
+
+export async function verifyPassword(password, storedHash) {
+  const [salt, hash] = storedHash.split(':');
+  if (!salt || !hash) return false;
+
+  const derivedKey = await new Promise((resolve, reject) => {
+    crypto.scrypt(password, salt, 64, (error, key) => {
+      if (error) reject(error);
+      else resolve(key.toString('hex'));
+    });
+  });
+
+  return crypto.timingSafeEqual(Buffer.from(hash, 'hex'), Buffer.from(derivedKey, 'hex'));
+}
+
+export function signToken(payload, expiresInSeconds = 60 * 60 * 24 * 7) {
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const now = Math.floor(Date.now() / 1000);
+  const body = { ...payload, iat: now, exp: now + expiresInSeconds };
+
+  const encodedHeader = base64UrlEncode(JSON.stringify(header));
+  const encodedBody = base64UrlEncode(JSON.stringify(body));
+  const message = `${encodedHeader}.${encodedBody}`;
+
+  const signature = crypto
+    .createHmac('sha256', TOKEN_SECRET)
+    .update(message)
+    .digest('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+
+  return `${message}.${signature}`;
+}
+
+export function verifyToken(token) {
+  try {
+    const [encodedHeader, encodedBody, signature] = token.split('.');
+    if (!encodedHeader || !encodedBody || !signature) return null;
+
+    const message = `${encodedHeader}.${encodedBody}`;
+    const expectedSignature = crypto
+      .createHmac('sha256', TOKEN_SECRET)
+      .update(message)
+      .digest('base64')
+      .replace(/=/g, '')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_');
+
+    if (expectedSignature !== signature) return null;
+
+    const payload = JSON.parse(base64UrlDecode(encodedBody));
+    if (payload.exp && payload.exp < Math.floor(Date.now() / 1000)) return null;
+
+    return payload;
+  } catch {
+    return null;
+  }
+}

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,0 +1,36 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+const DB_PATH = path.join(process.cwd(), 'data', 'db.json');
+
+const defaultDb = {
+  users: [],
+  posts: [],
+};
+
+/**
+ * Ensures a persistent JSON datastore exists before reads/writes.
+ */
+async function ensureDbFile() {
+  try {
+    await fs.access(DB_PATH);
+  } catch {
+    await fs.mkdir(path.dirname(DB_PATH), { recursive: true });
+    await fs.writeFile(DB_PATH, JSON.stringify(defaultDb, null, 2), 'utf-8');
+  }
+}
+
+export async function readDb() {
+  await ensureDbFile();
+  const content = await fs.readFile(DB_PATH, 'utf-8');
+  return JSON.parse(content);
+}
+
+export async function writeDb(nextDb) {
+  await ensureDbFile();
+  await fs.writeFile(DB_PATH, JSON.stringify(nextDb, null, 2), 'utf-8');
+}
+
+export function createId(prefix = 'id') {
+  return `${prefix}_${Date.now()}_${Math.random().toString(16).slice(2, 10)}`;
+}

--- a/lib/http.js
+++ b/lib/http.js
@@ -1,0 +1,20 @@
+import { cookies } from 'next/headers';
+import { verifyToken } from './auth';
+
+export function authCookieOptions() {
+  return {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+    path: '/',
+    maxAge: 60 * 60 * 24 * 7,
+  };
+}
+
+export async function getCurrentUserFromCookie() {
+  const cookieStore = await cookies();
+  const token = cookieStore.get('auth_token')?.value;
+  if (!token) return null;
+  const payload = verifyToken(token);
+  return payload ? { userId: payload.userId, email: payload.email, name: payload.name } : null;
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "seed": "node scripts/seed.mjs"
   },
   "dependencies": {
     "@fontsource/ibm-plex-sans": "^5.2.6",

--- a/scripts/seed.mjs
+++ b/scripts/seed.mjs
@@ -1,0 +1,65 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+const DB_PATH = path.join(process.cwd(), 'data', 'db.json');
+
+function createId(prefix) {
+  return `${prefix}_${Date.now()}_${Math.random().toString(16).slice(2, 10)}`;
+}
+
+function hashPassword(password) {
+  return new Promise((resolve, reject) => {
+    const salt = crypto.randomBytes(16).toString('hex');
+    crypto.scrypt(password, salt, 64, (error, key) => {
+      if (error) reject(error);
+      else resolve(`${salt}:${key.toString('hex')}`);
+    });
+  });
+}
+
+const now = new Date().toISOString();
+const userOneId = createId('user');
+const userTwoId = createId('user');
+
+const db = {
+  users: [
+    {
+      id: userOneId,
+      name: 'Aarav Demo',
+      email: 'aarav@example.com',
+      passwordHash: await hashPassword('password123'),
+      createdAt: now,
+    },
+    {
+      id: userTwoId,
+      name: 'Siya Demo',
+      email: 'siya@example.com',
+      passwordHash: await hashPassword('password123'),
+      createdAt: now,
+    },
+  ],
+  posts: [
+    {
+      id: createId('post'),
+      title: 'Welcome to HackFlow',
+      content: 'This sample post was seeded automatically. Start building from here!',
+      authorId: userOneId,
+      createdAt: now,
+      updatedAt: now,
+    },
+    {
+      id: createId('post'),
+      title: 'Hackathon Tip',
+      content: 'Keep your modules small and reusable to move faster under pressure.',
+      authorId: userTwoId,
+      createdAt: now,
+      updatedAt: now,
+    },
+  ],
+};
+
+await fs.mkdir(path.dirname(DB_PATH), { recursive: true });
+await fs.writeFile(DB_PATH, JSON.stringify(db, null, 2), 'utf-8');
+
+console.log('Seed complete. Demo users:\n- aarav@example.com / password123\n- siya@example.com / password123');


### PR DESCRIPTION
### Motivation
- Transform the minimal Next.js starter into a hackathon-ready full‑stack app that supports user authentication and dynamic content management. 
- Provide a simple, modular data layer and seed data so the app can be run locally without an external DB. 
- Add reusable components, global auth state, routing and responsive UI for a polished developer and user experience.

### Description
- Implemented backend API route handlers under `app/api/` for authentication (`signup`, `login`, `logout`, `me`) and post management (`GET/POST /api/posts`, `PUT/DELETE /api/posts/:id`) with author checks. 
- Added lightweight JWT-style signed tokens and password hashing in `lib/auth.js`, cookie helpers in `lib/http.js`, and a file-based datastore with `lib/db.js` backed by `data/db.json`. 
- Built frontend pieces: `AuthProvider` context in `components/providers/AuthProvider.jsx`, navigation in `components/layout/Navbar.jsx`, and post UI as `components/posts/PostForm.jsx` and `components/posts/PostCard.jsx`, plus pages for `/`, `/signup`, `/login`, and `/dashboard`. 
- Added `scripts/seed.mjs` and a `seed` npm script, updated `README.md`, and wired the layout into `app/layout.jsx` to provide a global auth wrapper and site chrome.

### Testing
- Ran `npm run seed` which executed `scripts/seed.mjs` and completed successfully (seeded demo users and posts). 
- Ran `npm run lint` which failed because the local `next` binary was not available in this environment (`sh: 1: next: not found`). 
- Attempted `npm install` in this runtime but dependency installation did not complete due to environment issues and repeated warnings, so full dependency-based tests could not be run. 
- Performed an automated browser screenshot attempt (Playwright) which failed because no server was reachable on port 3000 (`ERR_EMPTY_RESPONSE`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4c34e0e3883248f67a978fc4ae416)